### PR TITLE
feat: log blocks

### DIFF
--- a/chainsync.go
+++ b/chainsync.go
@@ -171,6 +171,11 @@ func (n *Node) chainsyncClientRollBackward(
 	point ocommon.Point,
 	tip ochainsync.Tip,
 ) error {
+	n.config.logger.Info(fmt.Sprintf(
+		"rollback: slot: %d, hash: %s",
+		point.Slot,
+		hex.EncodeToString(point.Hash),
+	))
 	n.chainsyncState.Rollback(
 		point.Slot,
 		hex.EncodeToString(point.Hash),
@@ -204,6 +209,11 @@ func (n *Node) chainsyncClientRollForward(
 	default:
 		return fmt.Errorf("unexpected block data type: %T", v)
 	}
+	n.config.logger.Info(fmt.Sprintf(
+		"chain extended, new tip: %s at slot %d",
+		blk.Hash(),
+		blk.SlotNumber(),
+	))
 	n.chainsyncState.AddBlock(
 		chainsync.ChainsyncBlock{
 			Point: chainsync.ChainsyncPoint{

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -24,11 +24,11 @@ import (
 
 func Run(logger *slog.Logger) error {
 	// TODO: make this configurable
-	l, err := net.Listen("tcp", ":3000")
+	l, err := net.Listen("tcp", ":3001")
 	if err != nil {
 		return err
 	}
-	logger.Info("listening for ouroboros node-to-node connections on :3000")
+	logger.Info("listening for ouroboros node-to-node connections on :3001")
 	n, err := node.New(
 		node.NewConfig(
 			node.WithLogger(logger),
@@ -60,7 +60,7 @@ func Run(logger *slog.Logger) error {
 		return err
 	}
 	go func() {
-		if err := n.StartMetrics(logger); err != nil {
+		if err := n.StartMetrics(); err != nil {
 			logger.Error("failed to start metrics listener %v", err)
 		}
 	}()

--- a/metrics.go
+++ b/metrics.go
@@ -15,15 +15,14 @@
 package node
 
 import (
-	"log/slog"
 	"net/http"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func (n *Node) StartMetrics(logger *slog.Logger) error {
+func (n *Node) StartMetrics() error {
 	http.Handle("/metrics", promhttp.Handler())
-	logger.Info("listening for prometheus metrics connections on :12798")
+	n.config.logger.Info("listening for prometheus metrics connections on :12798")
 	// TODO: make this configurable
 	err := http.ListenAndServe(":12798", nil)
 	if err != nil {


### PR DESCRIPTION
Log blocks as they pass through

```
{"time":"2024-05-21T12:38:17.335494548-04:00","level":"INFO","msg":"running: node version devel (commit 505b65a)"}
{"time":"2024-05-21T12:38:17.3356932-04:00","level":"INFO","msg":"listening for ouroboros node-to-node connections on :3001"}
{"time":"2024-05-21T12:38:17.335814615-04:00","level":"INFO","msg":"listening for prometheus metrics connections on :12798"}
{"time":"2024-05-21T12:38:17.619189658-04:00","level":"INFO","msg":"connected to node at preview-node.play.dev.cardano.org:3001"}
{"time":"2024-05-21T12:38:17.923596397-04:00","level":"INFO","msg":"rollback: slot: 49653463, hash: 5756c04c3fd07e9a25f395bfc9f6384a510c2ed69cab7b0b857ba6e4118f18b0"}
{"time":"2024-05-21T12:38:19.536800748-04:00","level":"INFO","msg":"chain extended, new tip: 5669bafc874749eceaff5eaddf97cc356fd2fd38e91ecea89f8dc165f1b1d289 at slot 49653499"}
```