### PR TITLE
chore: disable tracing

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -43,7 +43,7 @@ func Run(logger *slog.Logger) error {
 				},
 			),
 			// TODO: make this configurable
-			node.WithTracing(true),
+			//node.WithTracing(true),
 			// TODO: replace with parsing topology file
 			node.WithTopologyConfig(
 				&ouroboros.TopologyConfig{


### PR DESCRIPTION
It's not configurable yet, and it generates error logs when it can't connect to the default local endpoint