### PR TITLE
fix: move metrics into object instance

### DIFF
--- a/chainsync/chainsync.go
+++ b/chainsync/chainsync.go
@@ -30,17 +30,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var (
-	blockNum_int = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "cardano_node_metrics_blockNum_int",
-		Help: "current block number",
-	})
-	slotNum_int = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "cardano_node_metrics_slotNum_int",
-		Help: "current slot number",
-	})
-)
-
 type ChainsyncClientState struct {
 	Cursor               ocommon.Point
 	ChainIter            *state.ChainIterator
@@ -53,14 +42,28 @@ type State struct {
 	ledgerState  *state.LedgerState
 	clients      map[ouroboros.ConnectionId]*ChainsyncClientState
 	clientConnId *ouroboros.ConnectionId // TODO: replace with handling of multiple chainsync clients
+	metrics      struct {
+		blockNum prometheus.Gauge
+		slotNum  prometheus.Gauge
+	}
 }
 
 func NewState(eventBus *event.EventBus, ledgerState *state.LedgerState) *State {
-	return &State{
+	s := &State{
 		eventBus:    eventBus,
 		ledgerState: ledgerState,
 		clients:     make(map[ouroboros.ConnectionId]*ChainsyncClientState),
 	}
+	// Init metrics
+	s.metrics.blockNum = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cardano_node_metrics_blockNum_int",
+		Help: "current block number",
+	})
+	s.metrics.slotNum = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cardano_node_metrics_slotNum_int",
+		Help: "current slot number",
+	})
+	return s
 }
 
 func (s *State) AddClient(
@@ -116,8 +119,8 @@ func (s *State) AddBlock(block ledger.Block, blockType uint) error {
 	// block number isn't stored in the block itself
 	blockNumber := block.BlockNumber()
 	// Uodate metrics
-	blockNum_int.Set(float64(blockNumber))
-	slotNum_int.Set(float64(slotNumber))
+	s.metrics.blockNum.Set(float64(blockNumber))
+	s.metrics.slotNum.Set(float64(slotNumber))
 	// Generate event
 	blkHash, err := hex.DecodeString(block.Hash())
 	if err != nil {

--- a/event/event.go
+++ b/event/event.go
@@ -47,13 +47,16 @@ type EventBus struct {
 	sync.Mutex
 	subscribers map[EventType]map[EventSubscriberId]chan Event
 	lastSubId   EventSubscriberId
+	metrics     eventMetrics
 }
 
 // NewEventBus creates a new EventBus
 func NewEventBus() *EventBus {
-	return &EventBus{
+	e := &EventBus{
 		subscribers: make(map[EventType]map[EventSubscriberId]chan Event),
 	}
+	e.initMetrics()
+	return e
 }
 
 // Subscribe allows a consumer to receive events of a particular type via a channel
@@ -71,7 +74,7 @@ func (e *EventBus) Subscribe(eventType EventType) (EventSubscriberId, <-chan Eve
 	}
 	evtTypeSubs := e.subscribers[eventType]
 	evtTypeSubs[subId] = evtCh
-	metricSubscribers.WithLabelValues(string(eventType)).Inc()
+	e.metrics.subscribers.WithLabelValues(string(eventType)).Inc()
 	return subId, evtCh
 }
 
@@ -97,7 +100,7 @@ func (e *EventBus) Unsubscribe(eventType EventType, subId EventSubscriberId) {
 	if evtTypeSubs, ok := e.subscribers[eventType]; ok {
 		delete(evtTypeSubs, subId)
 	}
-	metricSubscribers.WithLabelValues(string(eventType)).Dec()
+	e.metrics.subscribers.WithLabelValues(string(eventType)).Dec()
 }
 
 // Publish allows a producer to send an event of a particular type to all subscribers
@@ -112,5 +115,5 @@ func (e *EventBus) Publish(eventType EventType, evt Event) {
 			subCh <- evt
 		}
 	}
-	metricEventsTotal.WithLabelValues(string(eventType)).Inc()
+	e.metrics.eventsTotal.WithLabelValues(string(eventType)).Inc()
 }

--- a/event/metrics.go
+++ b/event/metrics.go
@@ -19,19 +19,24 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-var (
-	metricEventsTotal = promauto.NewCounterVec(
+type eventMetrics struct {
+	eventsTotal *prometheus.CounterVec
+	subscribers *prometheus.GaugeVec
+}
+
+func (e *EventBus) initMetrics() {
+	e.metrics.eventsTotal = promauto.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "event_total",
 			Help: "total events by type",
 		},
 		[]string{"type"},
 	)
-	metricSubscribers = promauto.NewGaugeVec(
+	e.metrics.subscribers = promauto.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "event_subscribers",
 			Help: "subscribers by event type",
 		},
 		[]string{"type"},
 	)
-)
+}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -49,21 +49,6 @@ type RemoveTransactionEvent struct {
 	Hash string
 }
 
-var (
-	txsProcessedNum_int = promauto.NewCounter(prometheus.CounterOpts{
-		Name: "cardano_node_metrics_txsProcessedNum_int",
-		Help: "total transactions processed",
-	})
-	txsInMempool_int = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "cardano_node_metrics_txsInMempool_int",
-		Help: "current count of mempool transactions",
-	})
-	mempoolBytes_int = promauto.NewGauge(prometheus.GaugeOpts{
-		Name: "cardano_node_metrics_mempoolBytes_int",
-		Help: "current size of mempool transactions in bytes",
-	})
-)
-
 type MempoolTransaction struct {
 	Hash     string
 	Type     uint
@@ -80,6 +65,11 @@ type Mempool struct {
 	consumerIndex      map[ouroboros.ConnectionId]int
 	consumerIndexMutex sync.Mutex
 	transactions       []*MempoolTransaction
+	metrics            struct {
+		txsProcessedNum prometheus.Counter
+		txsInMempool    prometheus.Gauge
+		mempoolBytes    prometheus.Gauge
+	}
 }
 
 func NewMempool(logger *slog.Logger, eventBus *event.EventBus) *Mempool {
@@ -95,6 +85,19 @@ func NewMempool(logger *slog.Logger, eventBus *event.EventBus) *Mempool {
 	// TODO: replace this with purging based on on-chain TXs
 	// Schedule initial mempool expired cleanup
 	m.scheduleRemoveExpired()
+	// Init metrics
+	m.metrics.txsProcessedNum = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "cardano_node_metrics_txsProcessedNum_int",
+		Help: "total transactions processed",
+	})
+	m.metrics.txsInMempool = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cardano_node_metrics_txsInMempool_int",
+		Help: "current count of mempool transactions",
+	})
+	m.metrics.mempoolBytes = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "cardano_node_metrics_mempoolBytes_int",
+		Help: "current size of mempool transactions in bytes",
+	})
 	return m
 }
 
@@ -201,9 +204,9 @@ func (m *Mempool) AddTransaction(tx MempoolTransaction) error {
 	m.logger.Debug(
 		fmt.Sprintf("added transaction %s to mempool", tx.Hash),
 	)
-	txsProcessedNum_int.Inc()
-	txsInMempool_int.Inc()
-	mempoolBytes_int.Add(float64(len(tx.Cbor)))
+	m.metrics.txsProcessedNum.Inc()
+	m.metrics.txsInMempool.Inc()
+	m.metrics.mempoolBytes.Add(float64(len(tx.Cbor)))
 	// Send new TX to consumers that are ready for it
 	newTxIdx := len(m.transactions) - 1
 	for connId, consumerIdx := range m.consumerIndex {
@@ -268,8 +271,8 @@ func (m *Mempool) removeTransaction(hash string) bool {
 				txIdx,
 				txIdx+1,
 			)
-			txsInMempool_int.Dec()
-			mempoolBytes_int.Sub(float64(len(tx.Cbor)))
+			m.metrics.txsInMempool.Dec()
+			m.metrics.mempoolBytes.Sub(float64(len(tx.Cbor)))
 			// Update consumer indexes to reflect removed TX
 			for connId, consumerIdx := range m.consumerIndex {
 				// Decrement consumer index if the consumer has reached the removed TX


### PR DESCRIPTION
This allows node to be used as a library in cases where conflicting metrics may be defined