### PR TITLE
chore: move topology and conn manager to sub-packages

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,6 +19,8 @@ import (
 	"io"
 	"log/slog"
 
+	"github.com/blinklabs-io/node/topology"
+
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/prometheus/client_golang/prometheus"
@@ -35,7 +37,7 @@ type Config struct {
 	outboundSourcePort int
 	peerSharing        bool
 	promRegistry       prometheus.Registerer
-	topologyConfig     *TopologyConfig
+	topologyConfig     *topology.TopologyConfig
 	tracing            bool
 	tracingStdout      bool
 }
@@ -167,9 +169,9 @@ func WithPrometheusRegistry(registry prometheus.Registerer) ConfigOptionFunc {
 	}
 }
 
-// WithTopologyConfig specifies a TopologyConfig to use for outbound peers
+// WithTopologyConfig specifies a topology.TopologyConfig to use for outbound peers
 func WithTopologyConfig(
-	topologyConfig *TopologyConfig,
+	topologyConfig *topology.TopologyConfig,
 ) ConfigOptionFunc {
 	return func(c *Config) {
 		c.topologyConfig = topologyConfig

--- a/conn_manager/connection_manager.go
+++ b/conn_manager/connection_manager.go
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package node
+package conn_manager
 
 import (
 	"sync"
+
+	"github.com/blinklabs-io/node/topology"
 
 	ouroboros "github.com/blinklabs-io/gouroboros"
 )
@@ -101,11 +103,11 @@ func (c *ConnectionManager) AddHost(
 	)
 }
 
-func (c *ConnectionManager) AddHostsFromTopology(topology *TopologyConfig) {
-	for _, host := range topology.Producers {
+func (c *ConnectionManager) AddHostsFromTopology(topologyConfig *topology.TopologyConfig) {
+	for _, host := range topologyConfig.Producers {
 		c.AddHost(host.Address, host.Port, ConnectionManagerTagHostProducer)
 	}
-	for _, localRoot := range topology.LocalRoots {
+	for _, localRoot := range topologyConfig.LocalRoots {
 		for _, host := range localRoot.AccessPoints {
 			c.AddHost(
 				host.Address,
@@ -114,7 +116,7 @@ func (c *ConnectionManager) AddHostsFromTopology(topology *TopologyConfig) {
 			)
 		}
 	}
-	for _, publicRoot := range topology.PublicRoots {
+	for _, publicRoot := range topologyConfig.PublicRoots {
 		for _, host := range publicRoot.AccessPoints {
 			c.AddHost(
 				host.Address,

--- a/conn_manager/connection_manager_test.go
+++ b/conn_manager/connection_manager_test.go
@@ -12,28 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package node_test
+package conn_manager_test
 
 import (
 	"io"
 	"testing"
 	"time"
 
+	"github.com/blinklabs-io/node/conn_manager"
+
 	ouroboros "github.com/blinklabs-io/gouroboros"
 	"github.com/blinklabs-io/gouroboros/protocol/keepalive"
-	"github.com/blinklabs-io/node"
 	ouroboros_mock "github.com/blinklabs-io/ouroboros-mock"
 	"go.uber.org/goleak"
 )
 
 func TestConnectionManagerTagString(t *testing.T) {
-	testDefs := map[node.ConnectionManagerTag]string{
-		node.ConnectionManagerTagHostP2PLedger: "HostP2PLedger",
-		node.ConnectionManagerTagHostP2PGossip: "HostP2PGossip",
-		node.ConnectionManagerTagRoleInitiator: "RoleInitiator",
-		node.ConnectionManagerTagRoleResponder: "RoleResponder",
-		node.ConnectionManagerTagNone:          "Unknown",
-		node.ConnectionManagerTag(9999):        "Unknown",
+	testDefs := map[conn_manager.ConnectionManagerTag]string{
+		conn_manager.ConnectionManagerTagHostP2PLedger: "HostP2PLedger",
+		conn_manager.ConnectionManagerTagHostP2PGossip: "HostP2PGossip",
+		conn_manager.ConnectionManagerTagRoleInitiator: "RoleInitiator",
+		conn_manager.ConnectionManagerTagRoleResponder: "RoleResponder",
+		conn_manager.ConnectionManagerTagNone:          "Unknown",
+		conn_manager.ConnectionManagerTag(9999):        "Unknown",
 	}
 	for k, v := range testDefs {
 		if k.String() != v {
@@ -52,8 +53,8 @@ func TestConnectionManagerConnError(t *testing.T) {
 	var expectedConnId ouroboros.ConnectionId
 	expectedErr := io.EOF
 	doneChan := make(chan any)
-	connManager := node.NewConnectionManager(
-		node.ConnectionManagerConfig{
+	connManager := conn_manager.NewConnectionManager(
+		conn_manager.ConnectionManagerConfig{
 			ConnClosedFunc: func(connId ouroboros.ConnectionId, err error) {
 				if err != nil {
 					if connId != expectedConnId {
@@ -126,8 +127,8 @@ func TestConnectionManagerConnClosed(t *testing.T) {
 	defer goleak.VerifyNone(t)
 	var expectedConnId ouroboros.ConnectionId
 	doneChan := make(chan any)
-	connManager := node.NewConnectionManager(
-		node.ConnectionManagerConfig{
+	connManager := conn_manager.NewConnectionManager(
+		conn_manager.ConnectionManagerConfig{
 			ConnClosedFunc: func(connId ouroboros.ConnectionId, err error) {
 				if connId != expectedConnId {
 					t.Fatalf(

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -22,6 +22,7 @@ import (
 	"os"
 
 	"github.com/blinklabs-io/node"
+	"github.com/blinklabs-io/node/topology"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -63,10 +64,10 @@ func Run(logger *slog.Logger) error {
 			//node.WithTracing(true),
 			// TODO: replace with parsing topology file
 			node.WithTopologyConfig(
-				&node.TopologyConfig{
-					PublicRoots: []node.TopologyConfigP2PPublicRoot{
+				&topology.TopologyConfig{
+					PublicRoots: []topology.TopologyConfigP2PPublicRoot{
 						{
-							AccessPoints: []node.TopologyConfigP2PAccessPoint{
+							AccessPoints: []topology.TopologyConfigP2PAccessPoint{
 								{
 									Address: "preview-node.play.dev.cardano.org",
 									Port:    3001,

--- a/node.go
+++ b/node.go
@@ -22,6 +22,7 @@ import (
 
 	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
 	"github.com/blinklabs-io/node/chainsync"
+	"github.com/blinklabs-io/node/conn_manager"
 	"github.com/blinklabs-io/node/event"
 	"github.com/blinklabs-io/node/mempool"
 	"github.com/blinklabs-io/node/state"
@@ -31,7 +32,7 @@ import (
 
 type Node struct {
 	config                Config
-	connManager           *ConnectionManager
+	connManager           *conn_manager.ConnectionManager
 	chainsyncState        *chainsync.State
 	chainsyncBulkRangeEnd ocommon.Point
 	eventBus              *event.EventBus
@@ -79,8 +80,8 @@ func (n *Node) Run() error {
 	// Initialize chainsync state
 	n.chainsyncState = chainsync.NewState(n.eventBus, n.ledgerState, n.config.promRegistry)
 	// Configure connection manager
-	n.connManager = NewConnectionManager(
-		ConnectionManagerConfig{
+	n.connManager = conn_manager.NewConnectionManager(
+		conn_manager.ConnectionManagerConfig{
 			ConnClosedFunc: n.connectionManagerConnClosed,
 		},
 	)

--- a/topology/topology.go
+++ b/topology/topology.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package node
+package topology
 
 import (
 	"encoding/json"

--- a/topology/topology_test.go
+++ b/topology/topology_test.go
@@ -12,19 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package node_test
+package topology_test
 
 import (
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/blinklabs-io/node"
+	"github.com/blinklabs-io/node/topology"
 )
 
 type topologyTestDefinition struct {
 	jsonData       string
-	expectedObject *node.TopologyConfig
+	expectedObject *topology.TopologyConfig
 }
 
 var topologyTests = []topologyTestDefinition{
@@ -40,8 +40,8 @@ var topologyTests = []topologyTestDefinition{
   ]
 }
 `,
-		expectedObject: &node.TopologyConfig{
-			Producers: []node.TopologyConfigLegacyProducer{
+		expectedObject: &topology.TopologyConfig{
+			Producers: []topology.TopologyConfigLegacyProducer{
 				{
 					Address: "backbone.cardano.iog.io",
 					Port:    3001,
@@ -83,17 +83,17 @@ var topologyTests = []topologyTestDefinition{
   "useLedgerAfterSlot": 99532743
 }
 `,
-		expectedObject: &node.TopologyConfig{
-			LocalRoots: []node.TopologyConfigP2PLocalRoot{
+		expectedObject: &topology.TopologyConfig{
+			LocalRoots: []topology.TopologyConfigP2PLocalRoot{
 				{
-					AccessPoints: []node.TopologyConfigP2PAccessPoint{},
+					AccessPoints: []topology.TopologyConfigP2PAccessPoint{},
 					Advertise:    false,
 					Valency:      1,
 				},
 			},
-			PublicRoots: []node.TopologyConfigP2PPublicRoot{
+			PublicRoots: []topology.TopologyConfigP2PPublicRoot{
 				{
-					AccessPoints: []node.TopologyConfigP2PAccessPoint{
+					AccessPoints: []topology.TopologyConfigP2PAccessPoint{
 						{
 							Address: "backbone.cardano.iog.io",
 							Port:    3001,
@@ -102,7 +102,7 @@ var topologyTests = []topologyTestDefinition{
 					Advertise: false,
 				},
 				{
-					AccessPoints: []node.TopologyConfigP2PAccessPoint{
+					AccessPoints: []topology.TopologyConfigP2PAccessPoint{
 						{
 							Address: "backbone.mainnet.emurgornd.com",
 							Port:    3001,
@@ -118,7 +118,7 @@ var topologyTests = []topologyTestDefinition{
 
 func TestParseTopologyConfig(t *testing.T) {
 	for _, test := range topologyTests {
-		topology, err := node.NewTopologyConfigFromReader(
+		topology, err := topology.NewTopologyConfigFromReader(
 			strings.NewReader(test.jsonData),
 		)
 		if err != nil {


### PR DESCRIPTION
This reduces binary size when using node as a library and helps maintain isolation of components