### PR TITLE
feat: pass our logger to gouroboros

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -53,6 +53,7 @@ func (n *Node) startListener(l ListenerConfig) error {
 	}
 	// Build connection options
 	defaultConnOpts := []ouroboros.ConnectionOptionFunc{
+		ouroboros.WithLogger(n.config.logger),
 		ouroboros.WithNetworkMagic(n.config.networkMagic),
 		ouroboros.WithNodeToNode(!l.UseNtC),
 		ouroboros.WithServer(true),

--- a/outbound.go
+++ b/outbound.go
@@ -152,6 +152,7 @@ func (n *Node) createOutboundConnection(peer outboundPeer) error {
 	// Build connection options
 	connOpts := []ouroboros.ConnectionOptionFunc{
 		ouroboros.WithConnection(tmpConn),
+		ouroboros.WithLogger(n.config.logger),
 		ouroboros.WithNetworkMagic(n.config.networkMagic),
 		ouroboros.WithNodeToNode(true),
 		ouroboros.WithKeepAlive(true),


### PR DESCRIPTION
Before:
```
{"time":"2024-10-02T15:50:16.999576505Z","level":"INFO","msg":"maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined"}
{"time":"2024-10-02T15:50:16.999798605Z","level":"INFO","msg":"running: node version devel (commit 1d03356)"}
{"time":"2024-10-02T15:50:17.000176618Z","level":"INFO","msg":"listening for ouroboros node-to-node connections on 0.0.0.0:3001"}
{"time":"2024-10-02T15:50:17.000244064Z","level":"INFO","msg":"listening for prometheus metrics connections on 0.0.0.0:12798"}
{"time":"2024-10-02T15:50:17.217174315Z","level":"INFO","msg":"connected ouroboros to backbone.cardano.iog.io:3001"}
{"time":"2024-10-02T15:50:17.474158604Z","level":"INFO","msg":"chain rolled back, new tip: ff8bd997a9c3be29f231a505200ce99fee78b2e5d51bd4cd4ae270a6abf5f8bb at slot 136317911"}
{"time":"2024-10-02T15:50:56.681647556Z","level":"INFO","msg":"chain extended, new tip: 436065b150192f7e8b8f2b32b436a8fb344e9107bfaf9e3fccc7a0e50b4724a4 at slot 136317964"}
```

After:
```
{"time":"2024-10-02T16:59:50.207412729Z","level":"INFO","msg":"maxprocs: Leaving GOMAXPROCS=8: CPU quota undefined"}
{"time":"2024-10-02T16:59:50.207477601Z","level":"INFO","msg":"running: node version devel (commit 070c28f)"}
{"time":"2024-10-02T16:59:50.207633583Z","level":"DEBUG","msg":"loaded config: &{BindAddr:0.0.0.0 CardanoConfig:/opt/cardano/config/preview/config.json Network:mainnet MetricsPort:12798 Port:3001 Topology:/code/custom-p2p-topology.json}"}
{"time":"2024-10-02T16:59:50.207650227Z","level":"DEBUG","msg":"resolved topology: &{Producers:[] LocalRoots:[{AccessPoints:[] Advertise:false Trustable:false Valency:1}] PublicRoots:[{AccessPoints:[] Advertise:false Valency:0}] BootstrapPeers:[{Address:backbone.cardano.iog.io Port:3001}] UseLedgerAfterSlot:128908821}"}
{"time":"2024-10-02T16:59:50.207900294Z","level":"INFO","msg":"listening for ouroboros node-to-node connections on 0.0.0.0:3001"}
{"time":"2024-10-02T16:59:50.207970815Z","level":"INFO","msg":"listening for prometheus metrics connections on 0.0.0.0:12798"}
{"time":"2024-10-02T16:59:50.213218727Z","level":"DEBUG","msg":"adding host to connection manager: {Address:backbone.cardano.iog.io Port:3001 Tags:map[HostBootstrapPeer:true]}"}
{"time":"2024-10-02T16:59:50.213243083Z","level":"DEBUG","msg":"starting outbound connections"}
{"time":"2024-10-02T16:59:50.213257565Z","level":"DEBUG","msg":"adding bootstrap peer topology host: backbone.cardano.iog.io:3001"}
{"time":"2024-10-02T16:59:50.213278576Z","level":"DEBUG","msg":"establishing connection to: backbone.cardano.iog.io:3001"}
{"time":"2024-10-02T16:59:50.341699867Z","level":"DEBUG","msg":"establishing ouroboros protocol to backbone.cardano.iog.io:3001"}
{"time":"2024-10-02T16:59:50.341844654Z","level":"DEBUG","msg":"starting protocol: handshake"}
{"time":"2024-10-02T16:59:50.34186461Z","level":"DEBUG","msg":"registering protocol with muxer"}
{"time":"2024-10-02T16:59:50.445984561Z","level":"DEBUG","msg":"handling client message for handshake"}
{"time":"2024-10-02T16:59:50.446020301Z","level":"DEBUG","msg":"handling client accept version for handshake"}
{"time":"2024-10-02T16:59:50.446141192Z","level":"DEBUG","msg":"starting protocol: block-fetch"}
{"time":"2024-10-02T16:59:50.446163282Z","level":"DEBUG","msg":"registering protocol with muxer"}
{"time":"2024-10-02T16:59:50.446192781Z","level":"DEBUG","msg":"starting protocol: chain-sync"}
{"time":"2024-10-02T16:59:50.446203761Z","level":"DEBUG","msg":"registering protocol with muxer"}
{"time":"2024-10-02T16:59:50.446332742Z","level":"DEBUG","msg":"registering protocol with muxer"}
{"time":"2024-10-02T16:59:50.446383722Z","level":"DEBUG","msg":"registering protocol with muxer"}
{"time":"2024-10-02T16:59:50.446479066Z","level":"INFO","msg":"connected ouroboros to backbone.cardano.iog.io:3001"}
{"time":"2024-10-02T16:59:50.447064573Z","level":"DEBUG","msg":"client called chain-sync GetCurrentTip()"}
{"time":"2024-10-02T16:59:50.551087324Z","level":"DEBUG","msg":"handling client message for chain-sync"}
{"time":"2024-10-02T16:59:50.551112525Z","level":"DEBUG","msg":"handling client intersect not found for chain-sync"}
{"time":"2024-10-02T16:59:50.55118367Z","level":"DEBUG","msg":"client called chain-sync Sync(intersectPoints: [{_:{} Slot:136322097 Hash:[140 35 27 79 94 193 74 81 0 45 200 230 119 165 139 31 113 190 210 120 164 176 90 217 12 9 177 179 147 63 252 44]}])"}
{"time":"2024-10-02T16:59:50.654504766Z","level":"DEBUG","msg":"handling client message for chain-sync"}
{"time":"2024-10-02T16:59:50.654541814Z","level":"DEBUG","msg":"handling client intersect found for chain-sync"}
{"time":"2024-10-02T16:59:50.757636882Z","level":"DEBUG","msg":"handling client message for chain-sync"}
{"time":"2024-10-02T16:59:50.75766505Z","level":"DEBUG","msg":"handling client roll backward for chain-sync"}
{"time":"2024-10-02T16:59:50.758412786Z","level":"INFO","msg":"chain rolled back, new tip: 8c231b4f5ec14a51002dc8e677a58b1f71bed278a4b05ad90c09b1b3933ffc2c at slot 136322097"}
{"time":"2024-10-02T16:59:50.86126521Z","level":"DEBUG","msg":"handling client message for chain-sync"}
{"time":"2024-10-02T16:59:50.861288808Z","level":"DEBUG","msg":"handling client await reply for chain-sync"}
{"time":"2024-10-02T17:00:17.994965626Z","level":"DEBUG","msg":"handling client message for chain-sync"}
{"time":"2024-10-02T17:00:17.994990341Z","level":"DEBUG","msg":"handling client roll forward for chain-sync"}
{"time":"2024-10-02T17:00:17.995341724Z","level":"DEBUG","msg":"client called block-fetch GetBlock(point: {_:{} Slot:136322126 Hash:[58 194 215 89 191 29 118 22 202 237 118 234 103 126 73 93 169 51 189 223 77 169 197 52 159 231 222 223 254 3 211 79]})"}
{"time":"2024-10-02T17:00:18.102222301Z","level":"DEBUG","msg":"handling client message for block-fetch"}
{"time":"2024-10-02T17:00:18.102243509Z","level":"DEBUG","msg":"handling client start batch for block-fetch"}
{"time":"2024-10-02T17:00:18.215429993Z","level":"DEBUG","msg":"handling client message for block-fetch"}
{"time":"2024-10-02T17:00:18.215450452Z","level":"DEBUG","msg":"handling client block found for block-fetch"}
{"time":"2024-10-02T17:00:18.224511494Z","level":"DEBUG","msg":"handling client message for block-fetch"}
{"time":"2024-10-02T17:00:18.224523477Z","level":"DEBUG","msg":"handling client batch done for block-fetch"}
{"time":"2024-10-02T17:00:18.229551432Z","level":"INFO","msg":"chain extended, new tip: 3ac2d759bf1d7616caed76ea677e495da933bddf4da9c5349fe7dedffe03d34f at slot 136322126"}
{"time":"2024-10-02T17:00:18.333221266Z","level":"DEBUG","msg":"handling client message for chain-sync"}
{"time":"2024-10-02T17:00:18.333245887Z","level":"DEBUG","msg":"handling client await reply for chain-sync"}
```