### PR TITLE
fix: use CARDANO_DATABASE_PATH for persistent storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ ENV CARDANO_CONFIG=/opt/cardano/config/preview/config.json
 # Create data dir owned by container user and use it as default dir
 VOLUME /data
 WORKDIR /data
-ENV CARDANO_DATA_DIR=/data
+ENV CARDANO_DATABASE_PATH=/data
 ENTRYPOINT ["node"]

--- a/config.go
+++ b/config.go
@@ -110,8 +110,8 @@ func WithCardanoNodeConfig(
 	}
 }
 
-// WithDataDir specifies the persistent data directory to use. The default is to store everything in memory
-func WithDataDir(dataDir string) ConfigOptionFunc {
+// WithDatabasePath specifies the persistent data directory to use. The default is to store everything in memory
+func WithDatabasePath(dataDir string) ConfigOptionFunc {
 	return func(c *Config) {
 		c.dataDir = dataDir
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,7 +26,7 @@ import (
 type Config struct {
 	BindAddr      string `split_words:"true"`
 	CardanoConfig string `envconfig:"config"`
-	DataDir       string `split_words:"true"`
+	DatabasePath  string `split_words:"true"`
 	Network       string
 	MetricsPort   uint `split_words:"true"`
 	Port          uint
@@ -36,7 +36,7 @@ type Config struct {
 var globalConfig = &Config{
 	BindAddr:      "0.0.0.0",
 	CardanoConfig: "./configs/cardano/preview/config.json",
-	DataDir:       ".node",
+	DatabasePath:  ".node",
 	Network:       "preview",
 	MetricsPort:   12798,
 	Port:          3001,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -66,7 +66,7 @@ func Run(logger *slog.Logger) error {
 		node.NewConfig(
 			node.WithIntersectTip(true),
 			node.WithLogger(logger),
-			node.WithDataDir(cfg.DataDir),
+			node.WithDatabasePath(cfg.DatabasePath),
 			node.WithNetwork(cfg.Network),
 			node.WithCardanoNodeConfig(nodeCfg),
 			node.WithListeners(


### PR DESCRIPTION
This is the same as the `ghcr.io/blinklabs-io/cardano-node` image's `run-node` configuration.