### PR TITLE
feat: make chain-sync tip intersect configurable

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	BindAddr      string `split_words:"true"`
 	CardanoConfig string `envconfig:"config"`
 	DatabasePath  string `split_words:"true"`
+	IntersectTip  bool   `split_words:"true"`
 	Network       string
 	MetricsPort   uint `split_words:"true"`
 	Port          uint
@@ -37,6 +38,7 @@ var globalConfig = &Config{
 	BindAddr:      "0.0.0.0",
 	CardanoConfig: "./configs/cardano/preview/config.json",
 	DatabasePath:  ".node",
+	IntersectTip:  false,
 	Network:       "preview",
 	MetricsPort:   12798,
 	Port:          3001,

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -65,7 +65,7 @@ func Run(logger *slog.Logger) error {
 	)
 	n, err := node.New(
 		node.NewConfig(
-			node.WithIntersectTip(true),
+			node.WithIntersectTip(cfg.IntersectTip),
 			node.WithLogger(logger),
 			node.WithDatabasePath(cfg.DatabasePath),
 			node.WithNetwork(cfg.Network),


### PR DESCRIPTION
This also turns it off by default