### PR TITLE
feat: ledger metrics

### DIFF
--- a/node.go
+++ b/node.go
@@ -78,6 +78,7 @@ func (n *Node) Run() error {
 			EventBus:          n.eventBus,
 			Logger:            n.config.logger,
 			CardanoNodeConfig: n.config.cardanoNodeConfig,
+			PromRegistry:      n.config.promRegistry,
 		},
 	)
 	if err != nil {
@@ -88,7 +89,6 @@ func (n *Node) Run() error {
 	n.chainsyncState = chainsync.NewState(
 		n.eventBus,
 		n.ledgerState,
-		n.config.promRegistry,
 	)
 	// Configure connection manager
 	n.connManager = connmanager.NewConnectionManager(

--- a/state/metrics.go
+++ b/state/metrics.go
@@ -1,0 +1,53 @@
+// Copyright 2024 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package state
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type stateMetrics struct {
+	blockNum    prometheus.Gauge
+	density     prometheus.Gauge
+	epochNum    prometheus.Gauge
+	slotInEpoch prometheus.Gauge
+	slotNum     prometheus.Gauge
+}
+
+func (m *stateMetrics) init(promRegistry prometheus.Registerer) {
+	promautoFactory := promauto.With(promRegistry)
+	m.blockNum = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: "cardano_node_metrics_blockNum_int",
+		Help: "current block number",
+	})
+	// TODO: figure out how to calculate this
+	m.density = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: "cardano_node_metrics_density_real",
+		Help: "chain density",
+	})
+	m.epochNum = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: "cardano_node_metrics_epoch_int",
+		Help: "current epoch number",
+	})
+	m.slotInEpoch = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: "cardano_node_metrics_slotInEpoch_int",
+		Help: "current relative slot number in epoch",
+	})
+	m.slotNum = promautoFactory.NewGauge(prometheus.GaugeOpts{
+		Name: "cardano_node_metrics_slotNum_int",
+		Help: "current slot number",
+	})
+}


### PR DESCRIPTION
This moves the block/slot number metrics from chainsync and adds new metrics for the current epoch, the relative slot number in the current epoch, and the chain density (placeholder)

Fixes #60