### PR TITLE
fix: use string for uint64 database fields

### DIFF
--- a/database/types.go
+++ b/database/types.go
@@ -18,6 +18,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"math/big"
+	"strconv"
 )
 
 type Rat struct {
@@ -42,5 +43,24 @@ func (r *Rat) Scan(val any) error {
 	if _, ok := r.SetString(v); !ok {
 		return fmt.Errorf("failed to set big.Rat value from string: %s", v)
 	}
+	return nil
+}
+
+type Uint64 uint64
+
+func (u Uint64) Value() (driver.Value, error) {
+	return strconv.FormatUint(uint64(u), 10), nil
+}
+
+func (u *Uint64) Scan(val any) error {
+	v, ok := val.(string)
+	if !ok {
+		return fmt.Errorf("value was not expected type, wanted string, got %T", val)
+	}
+	tmpUint, err := strconv.ParseUint(v, 10, 64)
+	if err != nil {
+		return err
+	}
+	*u = Uint64(tmpUint)
 	return nil
 }

--- a/state/certs.go
+++ b/state/certs.go
@@ -35,8 +35,8 @@ func (ls *LedgerState) processTransactionCertificates(
 			tmpItem := models.PoolRegistration{
 				PoolKeyHash: cert.Operator[:],
 				VrfKeyHash:  cert.VrfKeyHash[:],
-				Pledge:      cert.Pledge,
-				Cost:        cert.Cost,
+				Pledge:      database.Uint64(cert.Pledge),
+				Cost:        database.Uint64(cert.Cost),
 				Margin:      &database.Rat{Rat: cert.Margin.Rat},
 				AddedSlot:   blockPoint.Slot,
 			}

--- a/state/models/pool_registration.go
+++ b/state/models/pool_registration.go
@@ -24,8 +24,8 @@ type PoolRegistration struct {
 	ID           uint   `gorm:"primarykey"`
 	PoolKeyHash  []byte `gorm:"index"`
 	VrfKeyHash   []byte
-	Pledge       uint64
-	Cost         uint64
+	Pledge       database.Uint64
+	Cost         database.Uint64
 	Margin       *database.Rat
 	Owners       []PoolRegistrationOwner
 	Relays       []PoolRegistrationRelay


### PR DESCRIPTION
Neither database/sql or sqlite in general can handle values larger than int64, so we use a string type to store them in the database