### PR TITLE
chore: tune sqlite connection params

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -191,8 +191,10 @@ func NewPersistent(
 		dataDir,
 		"metadata.sqlite",
 	)
+	// WAL journal mode, disable sync on write, increase cache size to 50MB (from 2MB)
+	metadataConnOpts := "_pragma=journal_mode(WAL)&_pragma=sync(OFF)&_pragma=cache_size(-50000)"
 	metadataDb, err := gorm.Open(
-		sqlite.Open(metadataDbPath),
+		sqlite.Open(fmt.Sprintf("file:%s?%s", metadataDbPath, metadataConnOpts)),
 		&gorm.Config{
 			Logger: gormlogger.Discard,
 		},


### PR DESCRIPTION
Switching to WAL, disabling sync on write, and increasing the cache size give a ~20% improvement in sync speed for the preview network